### PR TITLE
ci: fixes #1

### DIFF
--- a/.github/workflows/ci_v6.yml
+++ b/.github/workflows/ci_v6.yml
@@ -8,11 +8,17 @@ on:
 jobs:
   v6_test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        distro: [centos8, debian10, debian11, ubuntu2004, ubuntu2204]
+        distro: [centos8, debian10, debian11, ubuntu2004]
         mongo_ver: ["6.0.5"]
+        experimental: [false]
+        include:
+          - distro: ubuntu2204
+            mongo_ver: "6.0.5"
+            experimental: true
     env:
       PY_COLORS: "1"
       ANSIBLE_FORCE_COLOR: "1"


### PR DESCRIPTION
This is a workaround  for #1, the run is only failing on the tarball install. This allows the workflow to succeed when it fails on the ubuntu 22.04 job. 