### PR TITLE
Resolves #13

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ A clear and concise description of what you expected to happen.
 
 ### Your environment
 
-- Version of Ansible (`ansible --version`):
+- Version of Ansible, Molecule, and Python (Please paste the output from `ansible --version && molecule --version && python --version`):
 - Version of Jinja2:
 - Control node OS (e.g. Ubuntu 20.04, `cat /etc/os-release`):
 - Target node OS:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Common variables are listed below, along with default values (see `defaults/main
 | ------------------------- | --------- | ------------------------------------------------------ | --------- |
 | mongodb_pkg_install       | `true`    | Boolean, `true` to install MongoDB via package manager | No        |
 | mongodb_version           | `4.4.23`  | MongoDB Community stable releases `v4.4`, `v5`, `v6`   | Yes       |
+| mongodb_version_maj       | Automatic | Extracts major value from `mongodb_version`            | Automatic |
 | mongodb_version_maj_minor | Automatic | Extracts major and minor values from `mongodb_version` | Automatic |
 
 ### Package Install Variables
@@ -87,23 +88,25 @@ Common variables are listed below, along with default values (see `defaults/main
 | mongodb_tar_src_remote | `true`     | Boolean, `true` if downloading from URL (tar install)                 | No       |
 | mongodb_path_exec      | `/usr/bin` | PATH, MongoDB binary path (tar install)                               | No       |
 
-OS specific variables are listed below, along with default values:
+### Other OS Specific Variables
 
 `vars/debian.yml`:
 
-| Variable             | Default                             | Description                                 | Required |
-| -------------------- | ----------------------------------- | ------------------------------------------- | -------- |
-| mongodb_path_db      | `/var/lib/mongodb`                  | PATH, MongoDB database folder (tar install) | No       |
-| mongodb_path_log     | `/var/log/mongodb`                  | PATH, MongoDB log folder (tar install)      | No       |
-| mongodb_dependencies | `["libcurl4","openssl","liblzma5"]` | Required packages for MongoDB (tar install) | No       |
+| Variable              | Default                             | Description                                                         | Required |
+| --------------------- | ----------------------------------- | ------------------------------------------------------------------- | -------- |
+| mongodb_path_db       | `/var/lib/mongodb`                  | PATH, MongoDB database folder (tar install)                         | No       |
+| mongodb_path_log      | `/var/log/mongodb`                  | PATH, MongoDB log folder (tar install)                              | No       |
+| mongodb_dependencies  | `["libcurl4","openssl","liblzma5"]` | Required packages for MongoDB (tar install)                         | No       |
+| mongodb_pkg_hold_list | MongoDB Packages                    | List of MongoDB packages installed from `mongodb-org` (pkg install) | No       |
 
-`vars/redhat.yml`:
+`vars/redhat.yml` and `vars/redhat_mongo_v{4-6}.yml`:
 
-| Variable             | Default                                   | Description                                 | Required |
-| -------------------- | ----------------------------------------- | ------------------------------------------- | -------- |
-| mongodb_path_db      | `/var/lib/mongo`                          | PATH, MongoDB database folder (tar install) | No       |
-| mongodb_path_log     | `/var/log/mongodb`                        | PATH, MongoDB log folder (tar install)      | No       |
-| mongodb_dependencies | `["libcurl-minimal","openssl","xz-libs"]` | Required packages for MongoDB (tar install) | No       |
+| Variable              | Default                                   | Description                                                         | Required |
+| --------------------- | ----------------------------------------- | ------------------------------------------------------------------- | -------- |
+| mongodb_path_db       | `/var/lib/mongo`                          | PATH, MongoDB database folder (tar install)                         | No       |
+| mongodb_path_log      | `/var/log/mongodb`                        | PATH, MongoDB log folder (tar install)                              | No       |
+| mongodb_dependencies  | `["libcurl-minimal","openssl","xz-libs"]` | Required packages for MongoDB (tar install)                         | No       |
+| mongodb_pkg_hold_list | MongoDB Packages                          | List of MongoDB packages installed from `mongodb-org` (pkg install) | No       |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,21 +1,14 @@
 ---
 mongodb_pkg_install: true # false = install from tarball
-mongodb_version: "4.4.23"
+mongodb_version: '4.4.23'
+mongodb_version_maj: '{{ mongodb_version | regex_search("^\d") }}'
 mongodb_version_maj_minor: '{{ mongodb_version | regex_search("^\d.\d") }}'
 
 # package install variables
-mongodb_gpg_key: "https://pgp.mongodb.com/server-{{ mongodb_version_maj_minor }}.asc"
+mongodb_gpg_key: 'https://pgp.mongodb.com/server-{{ mongodb_version_maj_minor }}.asc'
 mongodb_pkg_hold: true
-mongodb_pkg_hold_list:
-  - mongodb-org
-  - mongodb-org-server
-  - mongodb-org-shell
-  - mongodb-org-mongos
-  - mongodb-org-tools
-  - mongodb-org-database
-  - mongodb-mongosh
 
 # tarball install variables
 mongodb_path_exec: /usr/bin
-mongodb_tar_src: "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-{{ mongodb_os_distro }}-{{ mongodb_version }}.tgz" # mongodb_os_distro is set within an OS specific task file.
+mongodb_tar_src: 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-{{ mongodb_os_distro }}-{{ mongodb_version }}.tgz' # mongodb_os_distro is set within an OS specific task file.
 mongodb_tar_src_remote: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,13 +6,13 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: "2.14"
+  min_ansible_version: '2.14'
 
   platforms:
     - name: Debian
       versions: [buster, bullseye]
     - name: EL
-      versions: ["8"]
+      versions: ['8']
     - name: Ubuntu
       versions: [focal, jammy]
 

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -1,6 +1,6 @@
 ---
 collections:
   - name: community.general
-    version: ">=6.0.0"
+    version: '>=6.0.0'
   - name: community.docker
-    version: ">=3.2.0"
+    version: '>=3.2.0'

--- a/tasks/debian-pkg-install.yml
+++ b/tasks/debian-pkg-install.yml
@@ -1,28 +1,28 @@
 - name: Add MongoDB gpg signing key
   ansible.builtin.apt_key:
-    url: "{{ mongodb_gpg_key }}"
+    url: '{{ mongodb_gpg_key }}'
     state: present
 
 - name: Add MongoDB repository into sources list
   ansible.builtin.apt_repository:
-    filename: "mongodb-org-{{ mongodb_version_maj_minor }}"
-    repo: "{{ mongodb_repository }}"
+    filename: 'mongodb-org-{{ mongodb_version_maj_minor }}'
+    repo: '{{ mongodb_repository }}'
     state: present
 
 - name: Install MongoDB
   ansible.builtin.apt:
     update_cache: true
     name:
-      - "mongodb-org={{ mongodb_version }}"
+      - 'mongodb-org={{ mongodb_version }}'
     state: present
   register: mongodb_pkg_install
   notify: Enable MongoDB
 
 - name: Hold MongoDB packages
   ansible.builtin.dpkg_selections:
-    name: "{{ mongodb_pkg }}"
+    name: '{{ mongodb_pkg }}'
     selection: hold
-  loop: "{{ mongodb_pkg_hold_list }}"
+  loop: '{{ mongodb_pkg_hold_list }}'
   loop_control:
     loop_var: mongodb_pkg
   when:

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -14,12 +14,12 @@
 # mongoDB download page url path value, e.g. "ubuntu2004" and "debian10"
 - name: Set variable 'mongodb_os_distro' for Debian
   ansible.builtin.set_fact:
-    mongodb_os_distro: "{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}"
-    mongodb_repository: "deb [ signed=/usr/share/keyrings/mongodb-server-{{ mongodb_version_maj_minor }}.gpg ] http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version_maj_minor }} main"
+    mongodb_os_distro: '{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}'
+    mongodb_repository: 'deb [ signed=/usr/share/keyrings/mongodb-server-{{ mongodb_version_maj_minor }}.gpg ] http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version_maj_minor }} main'
   when: ansible_distribution == 'Debian'
 
 - name: Set variable 'mongodb_os_distro' for Ubuntu
   ansible.builtin.set_fact:
     mongodb_os_distro: '{{ ansible_distribution | lower }}{{ ansible_distribution_version | regex_replace("[.]", "") }}'
-    mongodb_repository: "deb [ arch=amd64 signed=/usr/share/keyrings/mongodb-server-{{ mongodb_version_maj_minor }}.gpg ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version_maj_minor }} multiverse"
+    mongodb_repository: 'deb [ arch=amd64 signed=/usr/share/keyrings/mongodb-server-{{ mongodb_version_maj_minor }}.gpg ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version_maj_minor }} multiverse'
   when: ansible_distribution == 'Ubuntu'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 - name: Install essential packages and set OS specific variables
-  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_tasks: '{{ ansible_os_family | lower }}.yml'
 
 - name: Load OS specific variables
-  ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: '{{ ansible_os_family | lower }}.yml'
 
 - name: Install MongoDB dependencies
   ansible.builtin.package:
-    name: "{{ mongodb_dep_pkg }}"
+    name: '{{ mongodb_dep_pkg }}'
     state: present
-  loop: "{{ mongodb_dependencies }}"
+  loop: '{{ mongodb_dependencies }}'
   loop_control:
     loop_var: mongodb_dep_pkg
   register: package_status
@@ -20,8 +20,8 @@
 - name: Verify that required string variables are defined
   ansible.builtin.assert:
     that: mongodb_req_var is defined and mongodb_req_var | length > 0 and mongodb_req_var != None
-    fail_msg: " needs to be set for the role to work"
-    success_msg: "required variable is defined"
+    fail_msg: ' needs to be set for the role to work'
+    success_msg: 'required variable is defined'
   loop:
     - mongodb_version
     - mongodb_os_distro
@@ -35,13 +35,13 @@
   changed_when: mongodb_local_binary.rc
 
 - name: Install MongoDB via package manager
-  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}-pkg-install.yml"
+  ansible.builtin.include_tasks: '{{ ansible_os_family | lower }}-pkg-install.yml'
   when:
     - mongodb_pkg_install
     - mongodb_local_binary.rc != 0
 
 - name: Install MongoDB via tarball
-  ansible.builtin.include_tasks: "tarball-install.yml"
+  ansible.builtin.include_tasks: 'tarball-install.yml'
   when:
     - not mongodb_pkg_install
     - mongodb_local_binary.rc != 0

--- a/tasks/redhat-pkg-install.yml
+++ b/tasks/redhat-pkg-install.yml
@@ -23,6 +23,10 @@
     state: present
   when: mongodb_pkg_hold
 
+- name: Load MongoDB package hold list
+  ansible.builtin.include_vars: 'redhat_mongo_v{{ mongodb_version_maj }}.yml'
+  when: mongodb_pkg_hold
+
 - name: Hold MongoDB packages
   community.general.yum_versionlock:
     name: '{{ mongodb_pkg_hold_list }}'

--- a/tasks/redhat-pkg-install.yml
+++ b/tasks/redhat-pkg-install.yml
@@ -1,12 +1,12 @@
 ---
 - name: Add MongoDB repository
   ansible.builtin.yum_repository:
-    name: "mongodb-org-{{ mongodb_version_maj_minor }}"
+    name: 'mongodb-org-{{ mongodb_version_maj_minor }}'
     description: MongoDB Repository
-    baseurl: "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ mongodb_version_maj_minor }}/x86_64/"
+    baseurl: 'https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ mongodb_version_maj_minor }}/x86_64/'
     gpgcheck: true
     enabled: true
-    gpgkey: "{{ mongodb_gpg_key }}"
+    gpgkey: '{{ mongodb_gpg_key }}'
     state: present
 
 - name: Install MongoDB
@@ -25,7 +25,7 @@
 
 - name: Hold MongoDB packages
   community.general.yum_versionlock:
-    name: "{{ mongodb_pkg_hold_list }}"
+    name: '{{ mongodb_pkg_hold_list }}'
     state: present
   when:
     - mongodb_pkg_hold

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,5 +1,5 @@
 # mongoDB download page url path value, e.g. "rhel80" for RHEL and CentOS 8
 - name: Set variable 'mongodb_os_distro' for RHEL
   ansible.builtin.set_fact:
-    mongodb_os_distro: "rhel{{ ansible_distribution_major_version }}0"
+    mongodb_os_distro: 'rhel{{ ansible_distribution_major_version }}0'
   when: ansible_os_family == 'RedHat'

--- a/tasks/tarball-install.yml
+++ b/tasks/tarball-install.yml
@@ -1,9 +1,9 @@
 ---
 - name: Download and extract MongoDB tarfile
   ansible.builtin.unarchive:
-    src: "{{ mongodb_tar_src }}"
-    dest: "{{ mongodb_path_exec }}"
-    remote_src: "{{ mongodb_tar_src_remote }}"
+    src: '{{ mongodb_tar_src }}'
+    dest: '{{ mongodb_path_exec }}'
+    remote_src: '{{ mongodb_tar_src_remote }}'
     owner: root
     group: root
     mode: 0755
@@ -15,7 +15,7 @@
 - name: Create MongoDB user
   ansible.builtin.user:
     name: mongodb
-    comment: "MongoDB service account"
+    comment: 'MongoDB service account'
     system: true
     shell: /usr/sbin/nologin
     create_home: false
@@ -23,14 +23,14 @@
 
 - name: Create MongoDB directories
   ansible.builtin.file:
-    path: "{{ mongodb_path }}"
+    path: '{{ mongodb_path }}'
     state: directory
-    mode: "0755"
+    mode: '0755'
     owner: mongodb
     group: mongodb
   loop:
-    - "{{ mongodb_path_db }}"
-    - "{{ mongodb_path_log }}"
+    - '{{ mongodb_path_db }}'
+    - '{{ mongodb_path_log }}'
   loop_control:
     loop_var: mongodb_path
 
@@ -38,7 +38,7 @@
   ansible.builtin.template:
     src: mongod.conf.j2
     dest: /etc/mongod.conf
-    mode: "0644"
+    mode: '0644'
     owner: root
     group: root
 
@@ -46,6 +46,6 @@
   ansible.builtin.template:
     src: mongod.service.j2
     dest: /lib/systemd/system/mongod.service
-    mode: "0644"
+    mode: '0644'
     owner: root
     group: root

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -6,3 +6,11 @@ mongodb_dependencies:
   - libcurl4
   - openssl
   - liblzma5
+mongodb_pkg_hold_list:
+  - mongodb-org
+  - mongodb-org-server
+  - mongodb-org-shell
+  - mongodb-org-mongos
+  - mongodb-org-tools
+  - mongodb-org-database
+  - mongodb-mongosh

--- a/vars/redhat_mongo_v4.yml
+++ b/vars/redhat_mongo_v4.yml
@@ -1,0 +1,7 @@
+mongodb_pkg_hold_list:
+  - mongodb-org
+  - mongodb-org-database-tools-extra
+  - mongodb-org-mongos
+  - mongodb-org-server
+  - mongodb-org-shell
+  - mongodb-org-tools

--- a/vars/redhat_mongo_v5.yml
+++ b/vars/redhat_mongo_v5.yml
@@ -1,0 +1,8 @@
+mongodb_pkg_hold_list:
+  - mongodb-org
+  - mongodb-org-database
+  - mongodb-org-database-tools-extra
+  - mongodb-org-mongos
+  - mongodb-org-server
+  - mongodb-org-shell
+  - mongodb-org-tools

--- a/vars/redhat_mongo_v6.yml
+++ b/vars/redhat_mongo_v6.yml
@@ -1,0 +1,7 @@
+mongodb_pkg_hold_list:
+  - mongodb-org
+  - mongodb-org-database
+  - mongodb-org-database-tools-extra
+  - mongodb-org-mongos
+  - mongodb-org-server
+  - mongodb-org-tools


### PR DESCRIPTION
- Major
> - Resolves #13, RH installs now have `mongodb_pkg_hold_list` values based upon the requested MongoDB version.

- Minor
> - Change to default Ansible linter, reformat file for consistency. 
> - Add request for molecule and python version to Bug Issue Template
