### PR TITLE
fix: remove specific arch for Ubuntu repo list

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -21,5 +21,5 @@
 - name: Set variable 'mongodb_os_distro' for Ubuntu
   ansible.builtin.set_fact:
     mongodb_os_distro: '{{ ansible_distribution | lower }}{{ ansible_distribution_version | regex_replace("[.]", "") }}'
-    mongodb_repository: "deb [ arch=amd64 signed=/usr/share/keyrings/mongodb-server-{{ mongodb_version_maj_minor }}.gpg ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version_maj_minor }} multiverse"
+    mongodb_repository: "deb [ signed=/usr/share/keyrings/mongodb-server-{{ mongodb_version_maj_minor }}.gpg ] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{ mongodb_version_maj_minor }} multiverse"
   when: ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
Remove specific arch for ubuntu repository, execution failed with details:

- **Controller**: Docker, Ubuntu 22.04.5 LTS, aarch64, Python 3.10.12, ansible core 2.16.0
- **Inventory**: Docker, Ubuntu 22.04.5 LTS, aarch64

```sh
root@1b8a94571576:~# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.5 LTS
Release:	22.04
Codename:	jammy
root@1b8a94571576:~# uname -m
aarch64
root@1b8a94571576:~#
```

Simulation can be found [here](https://github.com/devetek/belajar-ansible/blob/main/ansible/requirements.yml#L41).