### PR TITLE
feat: add automatic replica set initialization for issue #87

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,12 @@ mongodb_config:
 
 mongodb_storage_journal_enabled: true          # Enable/Disable journal
 
+## replication Options
+mongodb_replication_replset: ""                   # Enable replication
+mongodb_replication_replindexprefetch: "all"      # specify index prefetching behavior (if secondary) [none|_id_only|all]
+mongodb_replication_oplogsize: 1024               # specifies a maximum size in megabytes for the replication operation log
+mongodb_replicaset_members: []                    # list of members of a replica set.
+
 
 # names and passwords for administrative users
 mongodb_user_admin_name: UserAdmin             # Name of the user for administrative tasks

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,4 +59,8 @@
 
 - name: Enable Security Authorization and Create Users
   ansible.builtin.include_tasks: auth_init.yml
-  when: mongodb_security_authorization == "enabled"
+  when: mongodb_security_authorization == "disabled"
+
+- name: Initialize MongoDB replicaset
+  ansible.builtin.include_tasks: replicaset.yml
+  when: mongodb_replication_replset is defined

--- a/tasks/replicaset.yml
+++ b/tasks/replicaset.yml
@@ -1,0 +1,10 @@
+- name: Ensure replicaset exists
+  community.mongodb.mongodb_replicaset:
+    login_host: localhost
+    login_user: "{{ mongodb_user_admin_name | default(omit) }}"
+    login_password: "{{ mongodb_user_admin_password | default(omit) }}"
+    replica_set: "{{ mongodb_replication_replset }}"
+    members: "{{ mongodb_replicaset_members }}"
+  vars:
+    ansible_python_interpreter: /opt/mongodb_venv/bin/python
+  when: mongo_role == "arbiter"

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -103,7 +103,19 @@ security:
 
 #operationProfiling:
 
-#replication:
+{% if mongodb_replication_replset -%}
+replication:
+  oplogSizeMB: {{ mongodb_replication_oplogsize | int }}
+  replSetName: {{ mongodb_replication_replset }}
+  {% if mongodb_storage_engine == 'mmapv1' -%}
+  secondaryIndexPrefetch: {{ mongodb_replication_replindexprefetch }}
+  {%- endif %}
+  {%- if mongodb_config['replication'] is defined and mongodb_config['replication'] is iterable %}
+  {%- for item in mongodb_config['replication'] -%}
+  {{ item }}
+  {% endfor %}
+  {% endif %}
+{% endif %}
 
 #sharding:
 


### PR DESCRIPTION
General problem or idea
In this ansible-role-mongodb, there is functionality for automatic creation of a replica set, controlled by the parameter `mongodb_replication_replset`

```
mongo
rs.initiate({
   _id : "dev_rs0",
   members: [
      { _id: 0, host: "host01:27017", priority: 2 },
      { _id: 1, host: "host02:27017" },
      { _id: 2, host: "host03:27017" }
   ]
})
```

With this update, the role handles replica set initialization automatically when the `mongodb_replication_replset` parameter is enabled, removing the need for manual commands.