### PR TITLE
fix: use galaxy as source for mongodb due to missing release tar file

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,3 +1,7 @@
 ---
-- src: https://github.com/ansible-collections/community.general
-- src: https://github.com/ansible-collections/community.mongodb
+collections:
+  - name: community.general
+    source: https://galaxy.ansible.com
+
+  - name: community.mongodb
+    source: https://galaxy.ansible.com


### PR DESCRIPTION
resolves #93, the mongodb github repo does not contain release versions or files.