### PR TITLE
Update disable-transparent-hugepages templates

### DIFF
--- a/templates/hugepages/disable-transparent-hugepages.amazon.service.j2
+++ b/templates/hugepages/disable-transparent-hugepages.amazon.service.j2
@@ -2,7 +2,9 @@
 [Unit]
 Description="Disable Transparent Hugepage before MongoDB boots"
 
-Before={{ mongodb_daemon_name }}.service
+DefaultDependencies=no
+After=sysinit.target local-fs.target
+Before=mongod.service
 
 [Service]
 Type=oneshot
@@ -12,4 +14,4 @@ ExecStart=-/bin/bash -c 'echo 0 > /sys/kernel/mm/transparent_hugepage/khugepaged
 
 [Install]
 
-RequiredBy={{ mongodb_daemon_name }}.service
+WantedBy=basic.target

--- a/templates/hugepages/disable-transparent-hugepages.debian.service.j2
+++ b/templates/hugepages/disable-transparent-hugepages.debian.service.j2
@@ -2,7 +2,9 @@
 [Unit]
 Description="Disable Transparent Hugepage before MongoDB boots"
 
-Before={{ mongodb_daemon_name }}.service
+DefaultDependencies=no
+After=sysinit.target local-fs.target
+Before=mongod.service
 
 [Service]
 Type=oneshot
@@ -11,5 +13,4 @@ ExecStart=-/bin/bash -c 'echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ExecStart=-/bin/bash -c 'echo 0 > /sys/kernel/mm/transparent_hugepage/khugepaged/defrag'
 
 [Install]
-
-RequiredBy={{ mongodb_daemon_name }}.service
+WantedBy=basic.target

--- a/templates/hugepages/disable-transparent-hugepages.redhat.service.j2
+++ b/templates/hugepages/disable-transparent-hugepages.redhat.service.j2
@@ -2,7 +2,9 @@
 [Unit]
 Description="Disable Transparent Hugepage before MongoDB boots"
 
-Before={{ mongodb_daemon_name }}.service
+DefaultDependencies=no
+After=sysinit.target local-fs.target
+Before=mongod.service
 
 [Service]
 Type=oneshot
@@ -12,4 +14,4 @@ ExecStart=-/bin/bash -c 'echo 0 > /sys/kernel/mm/redhat_transparent_hugepage/khu
 
 [Install]
 
-RequiredBy={{ mongodb_daemon_name }}.service
+WantedBy=basic.target


### PR DESCRIPTION
- Updated systemd templates (Amazon, Debian/Ubuntu, RedHat) to follow **MongoDB recommendations**: `DefaultDependencies=no, After=sysinit.target local-fs.target, Before=mongod.service, WantedBy=basic.target`.

- Fixes Ansible task failure on Ubuntu 22 with MongoDB 7, where `mongodb_daemon_name` variable was undefined (not present in the environment).

Verified: Ubuntu 22 with MongoDB 7